### PR TITLE
Fix conversion

### DIFF
--- a/bulletproofs/bip.go
+++ b/bulletproofs/bip.go
@@ -18,6 +18,7 @@
 package bulletproofs
 
 import (
+    "strconv"
     "crypto/sha256"
     "errors"
     "math/big"
@@ -79,7 +80,7 @@ func setupInnerProduct(H *p256.P256, g, h []*p256.P256, c *big.Int, N int64) (In
     if g == nil {
         params.Gg = make([]*p256.P256, params.N)
         for i := int64(0); i < params.N; i++ {
-            params.Gg[i], _ = p256.MapToGroup(SEEDH + "g" + string(i))
+            params.Gg[i], _ = p256.MapToGroup(SEEDH + "g" + strconv.FormatInt(i, 10))
         }
     } else {
         params.Gg = g
@@ -87,7 +88,7 @@ func setupInnerProduct(H *p256.P256, g, h []*p256.P256, c *big.Int, N int64) (In
     if h == nil {
         params.Hh = make([]*p256.P256, params.N)
         for i := int64(0); i < params.N; i++ {
-            params.Hh[i], _ = p256.MapToGroup(SEEDH + "h" + string(i))
+            params.Hh[i], _ = p256.MapToGroup(SEEDH + "h" + strconv.FormatInt(i, 10))
         }
     } else {
         params.Hh = h

--- a/bulletproofs/bp.go
+++ b/bulletproofs/bp.go
@@ -18,6 +18,7 @@
 package bulletproofs
 
 import (
+    "strconv"
     "crypto/rand"
     "errors"
     "fmt"
@@ -90,8 +91,8 @@ func Setup(b int64) (BulletProofSetupParams, error) {
     params.Gg = make([]*p256.P256, params.N)
     params.Hh = make([]*p256.P256, params.N)
     for i := int64(0); i < params.N; i++ {
-        params.Gg[i], _ = p256.MapToGroup(SEEDH + "g" + string(i))
-        params.Hh[i], _ = p256.MapToGroup(SEEDH + "h" + string(i))
+        params.Gg[i], _ = p256.MapToGroup(SEEDH + "g" + strconv.FormatInt(i, 10))
+        params.Hh[i], _ = p256.MapToGroup(SEEDH + "h" + strconv.FormatInt(i, 10))
     }
     return params, nil
 }


### PR DESCRIPTION
We were getting the following error before:
```
$ go test
# github.com/ing-bank/zkrp/bulletproofs
./bip.go:82:61: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./bip.go:90:61: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./bp.go:93:57: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./bp.go:94:57: conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	github.com/ing-bank/zkrp/bulletproofs [build failed]**
```